### PR TITLE
Retained and released delegate

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -195,6 +195,7 @@ navigationBarBackgroundImageLandscapePhone = _navigationBarBackgroundImageLandsc
 	[_previousButton release];
 	[_nextButton release];
     [_actionButton release];
+	[_delegate release];
   	[_depreciatedPhotoData release];
     [self releaseAllUnderlyingPhotos];
     [[SDImageCache sharedImageCache] clearMemory]; // clear memory


### PR DESCRIPTION
When using the photo browser with a split view controller there was a strange case that caused the application to crash because it didn't have a delegate. This issue was avoided if I used the initWithPhotos depreciated method. Instead of using that method I retained the delegate when the browser is initialized and I released it upon dealloc.
