### PR TITLE
Status bar shouldn't be shown after when was hidden before. Changed de dismissing behavior.

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.h
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.h
@@ -26,6 +26,7 @@
 - (id<MWPhoto>)photoBrowser:(MWPhotoBrowser *)photoBrowser photoAtIndex:(NSUInteger)index;
 @optional
 - (MWCaptionView *)photoBrowser:(MWPhotoBrowser *)photoBrowser captionViewForPhotoAtIndex:(NSUInteger)index;
+- (void)photoBrowserDidFinish:(MWPhotoBrowser *)photoBrowser;
 @end
 
 // MWPhotoBrowser

--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -52,6 +52,7 @@
     UIColor *_previousNavBarTintColor;
     UIBarStyle _previousNavBarStyle;
     UIStatusBarStyle _previousStatusBarStyle;
+	BOOL _previousStatusBarIsHidden;
     UIBarButtonItem *_previousViewControllerBackButton;
     
     // Misc
@@ -359,6 +360,7 @@ navigationBarBackgroundImageLandscapePhone = _navigationBarBackgroundImageLandsc
     // Status bar
     if (self.wantsFullScreenLayout && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
         _previousStatusBarStyle = [[UIApplication sharedApplication] statusBarStyle];
+		_previousStatusBarIsHidden = [[UIApplication sharedApplication] isStatusBarHidden];
         [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleBlackTranslucent animated:animated];
     }
     
@@ -395,6 +397,7 @@ navigationBarBackgroundImageLandscapePhone = _navigationBarBackgroundImageLandsc
     // Status bar
     if (self.wantsFullScreenLayout && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
         [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle animated:animated];
+		[[UIApplication sharedApplication] setStatusBarHidden:_previousStatusBarIsHidden withAnimation:animated?UIStatusBarAnimationFade:UIStatusBarAnimationNone];
     }
     
 	// Super
@@ -986,7 +989,12 @@ navigationBarBackgroundImageLandscapePhone = _navigationBarBackgroundImageLandsc
 #pragma mark - Misc
 
 - (void)doneButtonPressed:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+	if ([_delegate respondsToSelector:@selector(photoBrowserDidFinish:)]) {
+		[_delegate photoBrowserDidFinish:self];
+	}
+	else {
+		[self dismissModalViewControllerAnimated:YES];
+	}
 }
 
 - (void)actionButtonPressed:(id)sender {


### PR DESCRIPTION
- Fixed issue that made status bar to be displayed when MWPhotoBrowser is hidden even when status bar was hidden before.
- Added a new delegate callback to ask to be dismissed instead of dismissing itself (to match the behavior of UIKit view controllers, and allow the delegate to set references to nil).
