### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,11 @@ MWPhotoBrowser is an implementation of a photo browser similar to the native Pho
 [screenshot4_thumb]: http://dl.dropbox.com/u/2111839/Permanent/MWPhotoBrowser/mwphotobrowser4_thumb.png
 [screenshot4]: http://dl.dropbox.com/u/2111839/Permanent/MWPhotoBrowser/mwphotobrowser4.png
 
+<!-- MacBuildServer Install Button -->
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=Demo%2FPhotoBrowserDemo.xcodeproj&amp;target=PhotoBrowserDemo&amp;repo_url=git%3A%2F%2Fgithub.com%2Fmwaterfall%2FMWPhotoBrowser.git&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+<!-- MacBuildServer Install Button -->
 
 ## Usage
 


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
