### PR TITLE
When current image is loading, disable _actionButton

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -625,6 +625,7 @@ navigationBarBackgroundImageLandscapePhone = _navigationBarBackgroundImageLandsc
 #pragma mark - MWPhoto Loading Notification
 
 - (void)handleMWPhotoLoadingDidEndNotification:(NSNotification *)notification {
+    _actionButton.enabled = YES;
     id <MWPhoto> photo = [notification object];
     MWZoomingScrollView *page = [self pageDisplayingPhoto:photo];
     if (page) {
@@ -737,7 +738,7 @@ navigationBarBackgroundImageLandscapePhone = _navigationBarBackgroundImageLandsc
 
 // Handle page changes
 - (void)didStartViewingPageAtIndex:(NSUInteger)index {
-    
+    _actionButton.enabled = NO;
     // Release images further away than +/-1
     NSUInteger i;
     if (index > 0) {


### PR DESCRIPTION
I think it would be better if we disable actionButton while image is not loaded yet. This is very simple commit, only 2 new lines of code added.
