### PR TITLE
Fix a potential page index overrun when reloading data

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -532,6 +532,8 @@ navigationBarBackgroundImageLandscapePhone = _navigationBarBackgroundImageLandsc
     [_photos removeAllObjects];
     for (int i = 0; i < numberOfPhotos; i++) [_photos addObject:[NSNull null]];
     
+    [self setInitialPageIndex:_currentPageIndex];
+    
     // Update
     [self performLayout];
     


### PR DESCRIPTION
This fixes a problem where the view could wind up on (for example) page 3 of 2 after calling `[photoBrowser reloadData]`. This would happen if the photo browser was already loaded and the delegate returned a smaller number of photos when the data was reloaded (i.e. if one of the photos was removed).
