### PR TITLE
Fix : having __weak before the type is technically incorrect

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -1264,7 +1264,7 @@
                     });
 
                     // Show
-                    __weak typeof(self) weakSelf = self;
+                    __typeof__(self) __weak weakSelf = self;
                     [self.activityViewController setCompletionHandler:^(NSString *activityType, BOOL completed) {
                         weakSelf.activityViewController = nil;
                         [weakSelf hideControlsAfterDelay];


### PR DESCRIPTION
This is the right way of doing it: typeof(self) __weak wself = self; Note that having __weak before the type is "technically incorrect".

See here : https://developer.apple.com/library/mac/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html

From stackoverflow post : http://stackoverflow.com/questions/10892361/generic-typeof-for-weak-self-references

Example of errors I got with my project, it got fixed directly with my changes :
![screen shot 2013-10-10 at 12 03 47 pm](https://f.cloud.github.com/assets/216584/1307801/fe86ec58-31c4-11e3-87cc-b17b3eb3459b.png)
