### PR TITLE
Fix public currentPageIndex property name

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.h
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.h
@@ -43,7 +43,7 @@
 @property (nonatomic) BOOL zoomPhotosToFill;
 @property (nonatomic) BOOL displayNavArrows;
 @property (nonatomic) BOOL displayActionButton;
-@property (nonatomic, readonly) NSUInteger currentIndex;
+@property (nonatomic, readonly) NSUInteger currentPageIndex;
 
 // Init
 - (id)initWithPhotos:(NSArray *)photosArray  __attribute__((deprecated("Use initWithDelegate: instead"))); // Depreciated

--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -203,7 +203,7 @@
     NSArray *photosCopy = [_photos copy];
     for (id p in photosCopy) {
         if (p != [NSNull null]) {
-            if (preserveCurrent && p == [self photoAtIndex:self.currentIndex]) {
+            if (preserveCurrent && p == [self photoAtIndex:_currentPageIndex]) {
                 continue; // skip current
             }
             [p unloadUnderlyingImage];


### PR DESCRIPTION
There is a `currentIndex` public readonly property in `MWPhotoBrowser`.
There is no getter method, nor `self.currentIndex` or `_currentIndex` is assigned.
So it's always `0`.

On other hand there is a `_currentPageIndex` instance variable.
It's usefull to be able to get readonly access to this variable.

So I suggest to rename `currentIndex` property to `currentPageIndex` so it will become usefull.
