### PR TITLE
Add swipe gesture to close modal view

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -183,6 +183,11 @@
         _actionButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(actionButtonPressed:)];
     }
     
+    // add swipe down gesture to close window
+    UISwipeGestureRecognizer *swipeGesture = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(doneButtonPressed:)];
+    swipeGesture.direction = UISwipeGestureRecognizerDirectionDown;
+    [self.view addGestureRecognizer:swipeGesture];
+    
     // Update
     [self reloadData];
     


### PR DESCRIPTION
I added a swipe gesture to swipe down to dismiss the modal view. This gives similar behavior to the Facebook photo browser that users have come to expect. This should not interfere with any nav/push behaviors. I've been using this in my own implementation that got wiped out when I updated the project. Figured a pull request would be the best way to get my changes to stick.
