### PR TITLE
Add option hideControlsWhenDragging

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.h
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.h
@@ -47,6 +47,7 @@
 @property (nonatomic) BOOL displayActionButton;
 @property (nonatomic) BOOL displaySelectionButtons;
 @property (nonatomic) BOOL alwaysShowControls;
+@property (nonatomic) BOOL hideControlsWhenDragging;
 @property (nonatomic) BOOL enableGrid;
 @property (nonatomic) BOOL enableSwipeToDismiss;
 @property (nonatomic) BOOL startOnGrid;

--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -68,6 +68,7 @@
     _displayActionButton = YES;
     _displayNavArrows = NO;
     _zoomPhotosToFill = YES;
+    _hideControlsWhenDragging = YES;
     _performingLayout = NO; // Reset on view did appear
     _rotating = NO;
     _viewIsActive = NO;
@@ -1045,8 +1046,10 @@
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
-	// Hide controls when dragging begins
-	[self setControlsHidden:YES animated:YES permanent:NO];
+    // Hide controls when dragging begins
+    if (_hideControlsWhenDragging) {
+        [self setControlsHidden:YES animated:YES permanent:NO];
+    }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ browser.displayNavArrows = NO; // Whether to display left and right nav arrows o
 browser.displaySelectionButtons = NO; // Whether selection buttons are shown on each image (defaults to NO)
 browser.zoomPhotosToFill = YES; // Images that almost fill the screen will be initially zoomed to fill (defaults to YES)
 browser.alwaysShowControls = NO; // Allows to control whether the bars and controls are always visible or whether they fade away to show the photo full (defaults to NO)
+browser.hideControlsWhenDragging = YES; // Whether the bars and controls hide when swiping between photos (defaults to YES)
 browser.enableGrid = YES; // Whether to allow the viewing of all the photo thumbnails on a grid (defaults to YES)
 browser.startOnGrid = NO; // Whether to start on the grid of thumbnails instead of the first photo (defaults to NO)
 browser.wantsFullScreenLayout = YES; // iOS 5 & 6 only: Decide if you want the photo browser full screen, i.e. whether the status bar is affected (defaults to YES)


### PR DESCRIPTION
Adding an option to disable the default behavior of the bars/controls hiding when you begin to swipe between photos.

We found it a UX issue that users had to tap the screen every time between swiping in order to view the associated captions.