### PR TITLE
fix unintentional photo selection within grid view

### DIFF
--- a/MWPhotoBrowser/Classes/MWGridCell.m
+++ b/MWPhotoBrowser/Classes/MWGridCell.m
@@ -45,7 +45,7 @@
         [_selectedButton setImage:nil forState:UIControlStateNormal];
         [_selectedButton setImage:[UIImage imageNamed:@"MWPhotoBrowser.bundle/images/ImageSelectedSmallOff.png"] forState:UIControlStateNormal];
         [_selectedButton setImage:[UIImage imageNamed:@"MWPhotoBrowser.bundle/images/ImageSelectedSmallOn.png"] forState:UIControlStateSelected];
-        [_selectedButton addTarget:self action:@selector(selectionButtonPressed) forControlEvents:UIControlEventTouchDown];
+        [_selectedButton addTarget:self action:@selector(selectionButtonPressed) forControlEvents:UIControlEventTouchUpInside];
         _selectedButton.hidden = YES;
         _selectedButton.frame = CGRectMake(0, 0, 44, 44);
         [self addSubview:_selectedButton];


### PR DESCRIPTION
While in photo browser grid view with enabled selection, users
unintentionally select photos when scrolling through the collection of
photos. It was caused by the UIControlEventTouchDown control event
which made it too easy to select a photo, changing that to
UIControlEventTouchUpInside fixes the issue.

Thank you for creating a great library.
-Filip
