### PR TITLE
Make the MWPHOTO_PROGRESS_NOTIFICATION posted from main thread

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhoto.m
+++ b/MWPhotoBrowser/Classes/MWPhoto.m
@@ -163,7 +163,10 @@
                                                              NSDictionary* dict = [NSDictionary dictionaryWithObjectsAndKeys:
                                                                                    [NSNumber numberWithFloat:progress], @"progress",
                                                                                    self, @"photo", nil];
-                                                             [[NSNotificationCenter defaultCenter] postNotificationName:MWPHOTO_PROGRESS_NOTIFICATION object:dict];
+                                                             
+                                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                                                 [[NSNotificationCenter defaultCenter] postNotificationName:MWPHOTO_PROGRESS_NOTIFICATION object:dict];
+                                                             });
                                                          }
                                                      }
                                                     completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished) {


### PR DESCRIPTION
Because the progressBlock may be dispatched to the background thread
