### PR TITLE
ask delegate for which VC should present our modal content

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.h
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.h
@@ -36,7 +36,7 @@
 - (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser isPhotoSelectedAtIndex:(NSUInteger)index;
 - (void)photoBrowser:(MWPhotoBrowser *)photoBrowser photoAtIndex:(NSUInteger)index selectedChanged:(BOOL)selected;
 - (void)photoBrowserDidFinishModalPresentation:(MWPhotoBrowser *)photoBrowser;
-
+- (UIViewController *)presenterForModalViewControllers;
 @end
 
 @interface MWPhotoBrowser : UIViewController <UIScrollViewDelegate, UIActionSheetDelegate, MFMailComposeViewControllerDelegate>

--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -1515,7 +1515,11 @@
                         [weakSelf hideControlsAfterDelay];
                         [weakSelf hideProgressHUD:YES];
                     }];
-                    [self presentViewController:self.activityViewController animated:YES completion:nil];
+					UIViewController *presenter = self;
+					if ([_delegate respondsToSelector:@selector(presenterForModalViewControllers)]) {
+						presenter = [_delegate presenterForModalViewControllers];
+					}
+                    [presenter presentViewController:self.activityViewController animated:YES completion:nil];
                     
                 }
                 
@@ -1643,7 +1647,11 @@
         if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
             emailer.modalPresentationStyle = UIModalPresentationPageSheet;
         }
-        [self presentViewController:emailer animated:YES completion:nil];
+		UIViewController *presenter = self;
+		if ([_delegate respondsToSelector:@selector(presenterForModalViewControllers)]) {
+			presenter = [_delegate presenterForModalViewControllers];
+		}
+        [presenter presentViewController:emailer animated:YES completion:nil];
         [self hideProgressHUD:NO];
     }
 }
@@ -1655,7 +1663,7 @@
                                                         delegate:nil cancelButtonTitle:NSLocalizedString(@"Dismiss", nil) otherButtonTitles:nil];
 		[alert show];
     }
-    [self dismissViewControllerAnimated:YES completion:nil];
+    [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
Could we extend the MWPhotoBrowserDelegate protocol to defer to our delegate for which VC should present our modal content? In my app, when the MWPhotoBrowser presents the Email/Activity VCs, the OS prints out:

"Presenting view controllers on detached view controllers is discouraged"

Presenting these VCs from the keyWindow's rootVC resolves the issue for me.
If you merge this, would you update the podspec as well?
