### PR TITLE
Fix for iOS8 UIActivityViewController Popover Presentation on iPad

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -1515,6 +1515,10 @@
                         [weakSelf hideControlsAfterDelay];
                         [weakSelf hideProgressHUD:YES];
                     }];
+                    // iOS 8 - Set the Anchor Point for the popover
+                    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8")) {
+                        self.activityViewController.popoverPresentationController.barButtonItem = _actionButton;
+                    }
                     [self presentViewController:self.activityViewController animated:YES completion:nil];
                     
                 }


### PR DESCRIPTION
Tapping the Action button in iPad on iOS will generate a crash. This is because UIActivityViewControllers are presented in a UIPopoverController in iOS8. So, they need to be anchored. Added code to access the popover to set the anchor point.

See: http://stackoverflow.com/questions/25644054/uiactivityviewcontroller-crashing-on-ios8-ipads
