### PR TITLE
Support iPad on iOS8

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -1515,6 +1515,13 @@
                         [weakSelf hideControlsAfterDelay];
                         [weakSelf hideProgressHUD:YES];
                     }];
+
+                    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad && SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8")) {
+                        UIPopoverPresentationController *popover = self.activityViewController.popoverPresentationController;
+                        popover.barButtonItem = _actionButton;
+                        popover.permittedArrowDirections = UIPopoverArrowDirectionAny;
+                    }
+                    
                     [self presentViewController:self.activityViewController animated:YES completion:nil];
                     
                 }


### PR DESCRIPTION
The action item will cause a crash on the iPad on iOS 8 if either the sourceView, sourceRect, or barButtonItem is not set on the popover.
