### PR TITLE
Fixed Issue #304 "Zooming issue in iOS 8"

### DIFF
--- a/MWPhotoBrowser/Classes/MWZoomingScrollView.m
+++ b/MWPhotoBrowser/Classes/MWZoomingScrollView.m
@@ -346,6 +346,11 @@
 	[_photoBrowser hideControlsAfterDelay];
 }
 
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView {
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+}
+
 #pragma mark - Tap Detection
 
 - (void)handleSingleTap:(CGPoint)touchPoint {


### PR DESCRIPTION
This commit resolves the issue new to iOS 8 that causes the MWZoomingScrollView to jump to the top or left before animating the zoom effect.
The result of this fix is an elimination of the jumpy zooming behavior, and a return to the smooth zooming animation behavior seen before iOS 8.
This fix has been tested on both iOS 7 & iOS 8.

The cause seems to be a change to the way the layoutSubviews is called in iOS 8. The solution was to force the MWZoomingScrollView to layout its subViews in the scrollViewDidZoom method of the delegate.

See this thread for more information: http://stackoverflow.com/questions/25852883/uiscrollview-zoom-out-issue-ios-8-gm/26091731
