### PR TITLE
Exposed action button if the delegate conforms to the action button protocol

### DIFF
--- a/MWPhotoBrowser.xcworkspace/xcshareddata/MWPhotoBrowser.xccheckout
+++ b/MWPhotoBrowser.xcworkspace/xcshareddata/MWPhotoBrowser.xccheckout
@@ -11,17 +11,17 @@
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>9F9B14DA276794D9192F387F0CC62561009373D0</key>
-		<string>ssh://github.com/mwaterfall/MWPhotoBrowser.git</string>
+		<string>https://github.com/leetal/MWPhotoBrowser.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>MWPhotoBrowser/MWPhotoBrowser.xcodeproj/project.xcworkspace</string>
+	<string>MWPhotoBrowser.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>9F9B14DA276794D9192F387F0CC62561009373D0</key>
-		<string>../../..</string>
+		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/mwaterfall/MWPhotoBrowser.git</string>
+	<string>https://github.com/leetal/MWPhotoBrowser.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>

--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.h
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.h
@@ -32,7 +32,7 @@
 - (MWCaptionView *)photoBrowser:(MWPhotoBrowser *)photoBrowser captionViewForPhotoAtIndex:(NSUInteger)index;
 - (NSString *)photoBrowser:(MWPhotoBrowser *)photoBrowser titleForPhotoAtIndex:(NSUInteger)index;
 - (void)photoBrowser:(MWPhotoBrowser *)photoBrowser didDisplayPhotoAtIndex:(NSUInteger)index;
-- (void)photoBrowser:(MWPhotoBrowser *)photoBrowser actionButtonPressedForPhotoAtIndex:(NSUInteger)index;
+- (void)photoBrowser:(MWPhotoBrowser *)photoBrowser actionButtonPressed:(UIBarButtonItem*)actionButton forPhotoAtIndex:(NSUInteger)index;
 - (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser isPhotoSelectedAtIndex:(NSUInteger)index;
 - (void)photoBrowser:(MWPhotoBrowser *)photoBrowser photoAtIndex:(NSUInteger)index selectedChanged:(BOOL)selected;
 - (void)photoBrowserDidFinishModalPresentation:(MWPhotoBrowser *)photoBrowser;

--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.m
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.m
@@ -1462,10 +1462,10 @@
         if ([self numberOfPhotos] > 0 && [photo underlyingImage]) {
             
             // If they have defined a delegate method then just message them
-            if ([self.delegate respondsToSelector:@selector(photoBrowser:actionButtonPressedForPhotoAtIndex:)]) {
+            if ([self.delegate respondsToSelector:@selector(photoBrowser:actionButtonPressed:forPhotoAtIndex:)]) {
                 
                 // Let delegate handle things
-                [self.delegate photoBrowser:self actionButtonPressedForPhotoAtIndex:_currentPageIndex];
+                [self.delegate photoBrowser:self actionButtonPressed:_actionButton forPhotoAtIndex:_currentPageIndex];
                 
             } else {
                 


### PR DESCRIPTION
When using the `_actionButton` delegate callback, there is no need to hide the `_actionButton` since by then you have already handled over the control to the user. Now one can for example display actionsheets from that button and so on.