### PR TITLE
Fix for MWPhotoBrowser subclass compiler error in Swift

### DIFF
--- a/MWPhotoBrowser/Classes/MWPhotoBrowser.h
+++ b/MWPhotoBrowser/Classes/MWPhotoBrowser.h
@@ -56,6 +56,8 @@
 // Init
 - (id)initWithPhotos:(NSArray *)photosArray  __attribute__((deprecated("Use initWithDelegate: instead"))); // Depreciated
 - (id)initWithDelegate:(id <MWPhotoBrowserDelegate>)delegate;
+- (id)initWithCoder:(NSCoder *)decoder NS_DESIGNATED_INITIALIZER;
+- (id)init NS_DESIGNATED_INITIALIZER;
 
 // Reloads the photo browser and refetches data
 - (void)reloadData;


### PR DESCRIPTION
Trying to subclass MWPhotoBrowser in Swift 1.0 results in a compiler error:
![image](https://cloud.githubusercontent.com/assets/1509815/6340521/daae5d3a-bb74-11e4-975f-ccbf49a466aa.png)

Swift is not properly inferring the [designated initializers](http://useyourloaf.com/blog/2014/08/19/xcode-6-objective-c-modernization.html), so trying to call  `super.init()` results in an error, as does calling `super.init(delegate:)`.  Placing the signatures for `init` and `initWithCoder:` in the public header and marking them with `NS_DESIGNATED_INITIALIZER` seems to do the trick.

[This SO answer](https://stackoverflow.com/questions/26958155/subclassing-objective-c-classes-in-swift) *almost* gets the answer correct, but results in a plethora of compile time warnings in MWPhotoBrowser, because `initWithDelegate:` isn't a designated initializer! 