### PR TITLE
use a light status bar

### DIFF
--- a/Pod/Classes/MWPhotoBrowser.m
+++ b/Pod/Classes/MWPhotoBrowser.m
@@ -338,7 +338,7 @@
     }
     if (!_leaveStatusBarAlone && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
         _previousStatusBarStyle = [[UIApplication sharedApplication] statusBarStyle];
-        [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault animated:animated];
+        [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent animated:animated];
     }
     
     // Navigation bar appearance


### PR DESCRIPTION
when the user is not using VC-based status bar styles, let us use Light Content, instead of Default, since we are white-on-black interface


This is the PR related to #405