### PR TITLE
update SDWebImageOptions

### DIFF
--- a/Pod/Classes/MWPhoto.m
+++ b/Pod/Classes/MWPhoto.m
@@ -191,7 +191,7 @@
     @try {
         SDWebImageManager *manager = [SDWebImageManager sharedManager];
         _webImageOperation = [manager downloadImageWithURL:url
-                                                   options:0
+                                                   options:SDWebImageRetryFailed
                                                   progress:^(NSInteger receivedSize, NSInteger expectedSize) {
                                                       if (expectedSize > 0) {
                                                           float progress = receivedSize / (float)expectedSize;


### PR DESCRIPTION
Prevent from getting error status "Domain=NSURLErrorDomain Code=-1100 " while reconnect to Internet and re-download the image.