### PR TITLE
canSelectePhotoAtIndex

### DIFF
--- a/Example/MWPhotoBrowser/Menu.m
+++ b/Example/MWPhotoBrowser/Menu.m
@@ -1078,6 +1078,7 @@
         }
 		case 9: {
             @synchronized(_assets) {
+                startOnGrid = YES;
                 NSMutableArray *copy = [_assets copy];
                 if (NSClassFromString(@"PHAsset")) {
                     // Photos library
@@ -1192,6 +1193,8 @@
         return [_photos objectAtIndex:index];
     return nil;
 }
+
+
 
 - (id <MWPhoto>)photoBrowser:(MWPhotoBrowser *)photoBrowser thumbPhotoAtIndex:(NSUInteger)index {
     if (index < _thumbs.count)

--- a/Pod/Classes/MWGridCell.m
+++ b/Pod/Classes/MWGridCell.m
@@ -158,6 +158,13 @@
 }
 
 - (void)selectionButtonPressed {
+    if ([_gridController.browser.delegate respondsToSelector:@selector(photoBrowser:canSelectePhotoAtIndex:withPhotoCurrentState:)]) {
+        if ([_gridController.browser.delegate photoBrowser:_gridController.browser canSelectePhotoAtIndex:_index withPhotoCurrentState:_selectedButton.selected]) {
+                _selectedButton.selected = !_selectedButton.selected;
+        }
+    }else{
+        _selectedButton.selected = !_selectedButton.selected;
+    }
     _selectedButton.selected = !_selectedButton.selected;
     [_gridController.browser setPhotoSelected:_selectedButton.selected atIndex:_index];
 }

--- a/Pod/Classes/MWGridCell.m
+++ b/Pod/Classes/MWGridCell.m
@@ -158,8 +158,8 @@
 }
 
 - (void)selectionButtonPressed {
-    if ([_gridController.browser.delegate respondsToSelector:@selector(photoBrowser:canSelectePhotoAtIndex:withPhotoCurrentState:)]) {
-        if ([_gridController.browser.delegate photoBrowser:_gridController.browser canSelectePhotoAtIndex:_index withPhotoCurrentState:_selectedButton.selected]) {
+    if ([_gridController.browser.delegate respondsToSelector:@selector(photoBrowser:canSelectePhotoAtIndex:withPhotoCurrentStatus:)]) {
+        if ([_gridController.browser.delegate photoBrowser:_gridController.browser canSelectePhotoAtIndex:_index withPhotoCurrentStatus:_selectedButton.selected]) {
                 _selectedButton.selected = !_selectedButton.selected;
         }
     }else{

--- a/Pod/Classes/MWGridCell.m
+++ b/Pod/Classes/MWGridCell.m
@@ -165,7 +165,6 @@
     }else{
         _selectedButton.selected = !_selectedButton.selected;
     }
-    _selectedButton.selected = !_selectedButton.selected;
     [_gridController.browser setPhotoSelected:_selectedButton.selected atIndex:_index];
 }
 

--- a/Pod/Classes/MWPhotoBrowser.h
+++ b/Pod/Classes/MWPhotoBrowser.h
@@ -35,7 +35,7 @@
 - (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser isPhotoSelectedAtIndex:(NSUInteger)index;
 - (void)photoBrowser:(MWPhotoBrowser *)photoBrowser photoAtIndex:(NSUInteger)index selectedChanged:(BOOL)selected;
 - (void)photoBrowserDidFinishModalPresentation:(MWPhotoBrowser *)photoBrowser;
-- (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser canSelectePhotoAtIndex:(NSUInteger)index withPhotoCurrentState:(BOOL)selected;
+- (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser canSelectePhotoAtIndex:(NSUInteger)index withPhotoCurrentStatus:(BOOL)selected;
 @end
 
 @interface MWPhotoBrowser : UIViewController <UIScrollViewDelegate, UIActionSheetDelegate>

--- a/Pod/Classes/MWPhotoBrowser.h
+++ b/Pod/Classes/MWPhotoBrowser.h
@@ -35,7 +35,7 @@
 - (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser isPhotoSelectedAtIndex:(NSUInteger)index;
 - (void)photoBrowser:(MWPhotoBrowser *)photoBrowser photoAtIndex:(NSUInteger)index selectedChanged:(BOOL)selected;
 - (void)photoBrowserDidFinishModalPresentation:(MWPhotoBrowser *)photoBrowser;
-
+- (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser canSelectePhotoAtIndex:(NSUInteger)index withPhotoCurrentState:(BOOL)selected;
 @end
 
 @interface MWPhotoBrowser : UIViewController <UIScrollViewDelegate, UIActionSheetDelegate>

--- a/Pod/Classes/MWPhotoBrowser.m
+++ b/Pod/Classes/MWPhotoBrowser.m
@@ -1146,7 +1146,6 @@ static void * MWVideoPlayerObservation = &MWVideoPlayerObservation;
 
 - (void)selectedButtonTapped:(id)sender {
     UIButton *selectedButton = (UIButton *)sender;
-    selectedButton.selected = !selectedButton.selected;
     NSUInteger index = NSUIntegerMax;
     for (MWZoomingScrollView *page in _visiblePages) {
         if (page.selectedButton == selectedButton) {
@@ -1154,6 +1153,17 @@ static void * MWVideoPlayerObservation = &MWVideoPlayerObservation;
             break;
         }
     }
+    
+    if ([self.delegate respondsToSelector:@selector(photoBrowser:canSelectePhotoAtIndex:withPhotoCurrentState:)]) {
+        if ([self.delegate photoBrowser:self canSelectePhotoAtIndex:index withPhotoCurrentState:selectedButton.selected]) {
+            if (index != NSUIntegerMax) {
+                selectedButton.selected = !selectedButton.selected;
+            }
+        }
+    }else{
+        selectedButton.selected = !selectedButton.selected;
+    }
+    
     if (index != NSUIntegerMax) {
         [self setPhotoSelected:selectedButton.selected atIndex:index];
     }

--- a/Pod/Classes/MWPhotoBrowser.m
+++ b/Pod/Classes/MWPhotoBrowser.m
@@ -1154,8 +1154,8 @@ static void * MWVideoPlayerObservation = &MWVideoPlayerObservation;
         }
     }
     
-    if ([self.delegate respondsToSelector:@selector(photoBrowser:canSelectePhotoAtIndex:withPhotoCurrentState:)]) {
-        if ([self.delegate photoBrowser:self canSelectePhotoAtIndex:index withPhotoCurrentState:selectedButton.selected]) {
+    if ([self.delegate respondsToSelector:@selector(photoBrowser:canSelectePhotoAtIndex:withPhotoCurrentStatus:)]) {
+        if ([self.delegate photoBrowser:self canSelectePhotoAtIndex:index withPhotoCurrentStatus:selectedButton.selected]) {
             if (index != NSUIntegerMax) {
                 selectedButton.selected = !selectedButton.selected;
             }


### PR DESCRIPTION
like tableview, will provide a method named: 
- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath;


so, this method called before selection button click or tap, …
in MWPhtotBroswer.h, named
- (BOOL)photoBrowser:(MWPhotoBrowser *)photoBrowser canSelectePhotoAtIndex:(NSUInteger)index withPhotoCurrentState:(BOOL)selected;

cause  my app only allow user select 9 images max.