### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ pod "MWPhotoBrowser"
 
 To run the example project, clone the repo, and run `pod install` from the Example directory first.
 
-Then import the photo browser into your source files (or into your bridging header if you're using with Swift and not using frameworks with Cocoapods):
+Then import the photo browser into your source files (or into your bridging header if you're using with Swift and not using frameworks with CocoaPods):
 
 ```obj-c
 #import "MWPhotoBrowser.h"


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
