### PR TITLE
Change typeof to __typeof to work with more compiler configurations.

### DIFF
--- a/Pod/Classes/MWPhoto.m
+++ b/Pod/Classes/MWPhoto.m
@@ -122,11 +122,11 @@
         [self cancelVideoRequest]; // Cancel any existing
         PHVideoRequestOptions *options = [PHVideoRequestOptions new];
         options.networkAccessAllowed = YES;
-        typeof(self) __weak weakSelf = self;
+        __typeof(self) __weak weakSelf = self;
         _assetVideoRequestID = [[PHImageManager defaultManager] requestAVAssetForVideo:_asset options:options resultHandler:^(AVAsset *asset, AVAudioMix *audioMix, NSDictionary *info) {
             
             // dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{ // Testing
-            typeof(self) strongSelf = weakSelf;
+            __typeof(self) strongSelf = weakSelf;
             if (!strongSelf) return;
             strongSelf->_assetVideoRequestID = PHInvalidImageRequestID;
             if ([asset isKindOfClass:[AVURLAsset class]]) {

--- a/Pod/Classes/MWPhotoBrowser.m
+++ b/Pod/Classes/MWPhotoBrowser.m
@@ -1201,11 +1201,11 @@ static void * MWVideoPlayerObservation = &MWVideoPlayerObservation;
         [self setVideoLoadingIndicatorVisible:YES atPageIndex:index];
 
         // Get video and play
-        typeof(self) __weak weakSelf = self;
+        __typeof(self) __weak weakSelf = self;
         [photo getVideoURL:^(NSURL *url) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 // If the video is not playing anymore then bail
-                typeof(self) strongSelf = weakSelf;
+                __typeof(self) strongSelf = weakSelf;
                 if (!strongSelf) return;
                 if (strongSelf->_currentVideoIndex != index || !strongSelf->_viewIsActive) {
                     return;


### PR DESCRIPTION
Replaces PR #530 which had some other modifications.

Depending on the compiler settings, the construct typeof(self) __weak weakSelf = self; can trigger a compiler warning: Expected ';' after expression.

Changing to __typeof will work with more configurations, per http://stackoverflow.com/a/32145709/1758224
